### PR TITLE
Add in tests for Telegram, MatricCard, Course class. Update regex for valid inputs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -58,7 +58,7 @@ Below are the features that can be completed using command line interface (CLI).
 
 Add a new person to UNite.
 
-Format: `add n/NAME p/PHONE e/EMAIL a/ADDRESS c/COURSE tele/TELEGRAM m/MATRIC CARD t/TAG`
+Format: `add n/NAME p/PHONE e/EMAIL a/ADDRESS c/COURSE tele/TELEGRAM m/MATRICCARD t/TAG`
 
 * The order of input does not matter.
 * `n/NAME p/PHONE e/EMAIL a/ADDRESS` are the 4 required information that must be present.

--- a/src/main/java/seedu/address/model/person/Course.java
+++ b/src/main/java/seedu/address/model/person/Course.java
@@ -10,18 +10,18 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Course {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Course should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Course should only contain alphabet characters and spaces.";
 
     /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * Input can be blank space, if you input blank spaces,
+     * it is treated as if the course field is unfilled and blank.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alpha}][\\p{Alpha} ]*";
 
     public final String value;
 
     /**
-     * Constructs a {@code MatricCard}.
+     * Constructs a {@code Course}.
      *
      * @param courseName A valid courseName.
      */

--- a/src/main/java/seedu/address/model/person/MatricCard.java
+++ b/src/main/java/seedu/address/model/person/MatricCard.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class MatricCard {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Matric Card should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Matric Card should only contain alphanumeric characters, and it should be one word";
 
     /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * Input can be blank space, if you input blank spaces,
+     * it is treated as if the course field is unfilled and blank.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}]*";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/Telegram.java
+++ b/src/main/java/seedu/address/model/person/Telegram.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Telegram {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Telegram ID should only contain alphanumeric characters and underscore, and it should be one word";
 
     /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * Input can be blank space, if you input blank spaces,
+     * it is treated as if the course field is unfilled and blank.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}\\_]*";
 
     public final String id;
 

--- a/src/test/java/seedu/address/model/person/CourseTest.java
+++ b/src/test/java/seedu/address/model/person/CourseTest.java
@@ -1,0 +1,37 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class CourseTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Address(null));
+    }
+
+    @Test
+    public void constructor_invalidCourse_throwsIllegalArgumentException() {
+        String invalidCourse = "Math@";
+        assertThrows(IllegalArgumentException.class, () -> new Course(invalidCourse));
+    }
+
+    @Test
+    public void isValidCourse() {
+        // null course
+        assertThrows(NullPointerException.class, () -> Course.isValidCourse(null));
+
+        // invalid course
+        assertFalse(Course.isValidCourse("@")); // symbols
+        assertFalse(Course.isValidCourse("123")); // spaces only
+
+        // valid course
+        assertTrue(Course.isValidCourse("")); // blank spaces (after trimmed)
+        assertTrue(Course.isValidCourse("Math"));
+        assertTrue(Course.isValidCourse("a")); // one character
+        assertTrue(Course.isValidCourse("Computer Science and Mathematics")); // long course
+    }
+}

--- a/src/test/java/seedu/address/model/person/MatricCardTest.java
+++ b/src/test/java/seedu/address/model/person/MatricCardTest.java
@@ -1,0 +1,36 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class MatricCardTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new MatricCard(null));
+    }
+
+    @Test
+    public void constructor_invalidMatricCard_throwsIllegalArgumentException() {
+        String invalidMatricCard = "A123123@";
+        assertThrows(IllegalArgumentException.class, () -> new MatricCard(invalidMatricCard));
+    }
+
+    @Test
+    public void isValidMatricCard() {
+        // null matric card
+        assertThrows(NullPointerException.class, () -> MatricCard.isValidMatricCard(null));
+
+        // invalid matric card
+        assertFalse(MatricCard.isValidMatricCard("@")); // symbols
+        assertFalse(MatricCard.isValidMatricCard("alice test")); // two words
+
+
+        // valid matric card
+        assertTrue(MatricCard.isValidMatricCard("")); // blank spaces (after trimmed)
+        assertTrue(MatricCard.isValidMatricCard("A1231234E"));
+    }
+}

--- a/src/test/java/seedu/address/model/person/TelegramTest.java
+++ b/src/test/java/seedu/address/model/person/TelegramTest.java
@@ -1,0 +1,38 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class TelegramTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Telegram(null));
+    }
+
+    @Test
+    public void constructor_invalidTelegramId_throwsIllegalArgumentException() {
+        String invalidTelegramId = "alice@@";
+        assertThrows(IllegalArgumentException.class, () -> new Telegram(invalidTelegramId));
+    }
+
+    @Test
+    public void isValidTelegramId() {
+        // null telegram id
+        assertThrows(NullPointerException.class, () -> Telegram.isValidTelegramId(null));
+
+        // invalid telegram id
+        assertFalse(Telegram.isValidTelegramId("@")); // symbols
+        assertFalse(Telegram.isValidTelegramId("alice test")); // two words
+
+
+        // valid telegram id
+        assertTrue(Telegram.isValidTelegramId("")); // blank spaces (after trimmed)
+        assertTrue(Telegram.isValidTelegramId("alice123"));
+        assertTrue(Telegram.isValidTelegramId("alice_123")); // with underscore
+        assertTrue(Telegram.isValidTelegramId("alice_test_1234")); // long telegram id
+    }
+}


### PR DESCRIPTION
Summary 
1. Add in tests for Telegram, MatricCard and Course class. 
2. Update regex for valid input for Telegram, MatricCard and Course class. 

Regex of the Telegram, MatricCard and Course class updates as follow. 
- `Telegram` - Telegram ID should only contain alphanumeric characters and underscore, and it should be one word
- `Course` - Course should only contain alphabet characters and spaces
- `MatricCard`  - Matric Card should only contain alphanumeric characters, and it should be one word

❗ This update of valid input may crash your program and throws a UI Fatal Error : IndexOutOfBound error due to the mismatch of validity of these fields of your current address book.

To fix this, simply delete your addressbook.json under ./data and let your program automatically creates a new default one for you. Alternatively, go to your addressbook.json file and change the invalid fields. 



