### PR TITLE
Fix 4 bugs (3 from PE-D, 1 from previously discovered bugs)

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ProfileCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ProfileCommandParser.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ProfileCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.ui.UiManager;
 
 /**
  * Parses input arguments and creates a new ProfileCommand object
@@ -20,7 +19,6 @@ public class ProfileCommandParser implements Parser<ProfileCommand> {
     public ProfileCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
-            UiManager.getMainWindow().getPersonListPanel().getPersonListView().scrollTo(index.getZeroBased());
             return new ProfileCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -35,15 +35,15 @@ public class MainWindow extends UiPart<Stage> {
 
     private final Logger logger = LogsCenter.getLogger(getClass());
 
-    private Stage primaryStage;
-    private Logic logic;
+    private final Stage primaryStage;
+    private final Logic logic;
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
     private ResultDisplay resultDisplay;
-    private HelpWindow helpWindow;
-    private AddTagWindow addTagWindow;
-    private AddProfileWindow addProfileWindow;
+    private final HelpWindow helpWindow;
+    private final AddTagWindow addTagWindow;
+    private final AddProfileWindow addProfileWindow;
     private GeneralDisplay generalDisplay;
 
     @FXML
@@ -254,10 +254,14 @@ public class MainWindow extends UiPart<Stage> {
                 addMenu.setVisible(true);
                 newTagMenu.setVisible(true);
                 themeMenu.setVisible(true);
+                personListPanel.toggleRightClick(true);
+                generalDisplay.getTagList().toggleRightClick(true);
             } else {
                 addMenu.setVisible(false);
                 newTagMenu.setVisible(false);
                 themeMenu.setVisible(false);
+                personListPanel.toggleRightClick(false);
+                generalDisplay.getTagList().toggleRightClick(false);
             }
 
             if (commandResult.isRemoveProfile() && this.generalDisplay.getProfile().getPerson() != null

--- a/src/main/java/seedu/address/ui/general/GeneralDisplay.java
+++ b/src/main/java/seedu/address/ui/general/GeneralDisplay.java
@@ -15,9 +15,9 @@ import seedu.address.ui.UiPart;
  */
 public class GeneralDisplay extends UiPart<Region> {
     private static final String FXML = "GeneralDisplay.fxml";
-    private Profile profile;
-    private TagList tagList;
-    private GrabResult grabResult;
+    private final Profile profile;
+    private final TagList tagList;
+    private final GrabResult grabResult;
 
     @FXML
     private StackPane profileDisplayPlaceholder;
@@ -78,6 +78,10 @@ public class GeneralDisplay extends UiPart<Region> {
 
     public Profile getProfile() {
         return profile;
+    }
+
+    public TagList getTagList() {
+        return tagList;
     }
 
     public void resetProfile() {

--- a/src/main/java/seedu/address/ui/general/Profile.java
+++ b/src/main/java/seedu/address/ui/general/Profile.java
@@ -6,6 +6,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
+import javafx.scene.text.Text;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.Person;
 import seedu.address.ui.UiManager;
@@ -18,21 +19,19 @@ public class Profile extends UiPart<Region> {
     private Person person;
 
     @FXML
-    private Label name;
+    private Text name;
     @FXML
-    private Label id;
+    private Text phone;
     @FXML
-    private Label phone;
+    private Text address;
     @FXML
-    private Label address;
+    private Text email;
     @FXML
-    private Label email;
+    private Text telegram;
     @FXML
-    private Label telegram;
+    private Text matriculation;
     @FXML
-    private Label matriculation;
-    @FXML
-    private Label course;
+    private Text course;
     @FXML
     private FlowPane tags;
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -364,16 +364,10 @@
     -fx-font-size: 11;
 }
 
-.profile_big_label {
+.profile_text {
     -fx-font-family: "Segoe UI";
     -fx-font-size: 15px;
-    -fx-text-fill: white;
-}
-
-.profile_small_label {
-    -fx-font-family: "Segoe UI";
-    -fx-font-size: 15px;
-    -fx-text-fill: white;
+    -fx-fill: white
 }
 
 .profile_information_label {

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -366,16 +366,10 @@
     -fx-font-size: 11;
 }
 
-.profile_big_label {
+.profile_text {
     -fx-font-family: "Segoe UI";
     -fx-font-size: 15px;
-    -fx-text-fill: black;
-}
-
-.profile_small_label {
-    -fx-font-family: "Segoe UI";
-    -fx-font-size: 15px;
-    -fx-text-fill: black;
+    -fx-fill: black
 }
 
 .profile_information_label {

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -25,12 +25,12 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" textOverrun="CENTER_WORD_ELLIPSIS"/>
       </HBox>
       <FlowPane fx:id="tags" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" textOverrun="CENTER_WORD_ELLIPSIS"/>
+      <Label fx:id="address" styleClass="cell_small_label" text="\$address" textOverrun="CENTER_WORD_ELLIPSIS"/>
+      <Label fx:id="email" styleClass="cell_small_label" text="\$email" textOverrun="CENTER_WORD_ELLIPSIS"/>
     </VBox>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -4,6 +4,5 @@
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <ListView fx:id="personListView" VBox.vgrow="ALWAYS" onMouseClicked="#handleSelect" onKeyPressed="#handleSelect"
-            onContextMenuRequested="#handleContextMenu"/>
+  <ListView fx:id="personListView" VBox.vgrow="ALWAYS" onMouseClicked="#handleMouseSelect" onKeyPressed="#handleKeySelect"/>
 </VBox>

--- a/src/main/resources/view/Profile.fxml
+++ b/src/main/resources/view/Profile.fxml
@@ -9,6 +9,8 @@
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.HBox?>
 
+<?import javafx.scene.text.Text?>
+<?import javafx.scene.text.TextFlow?>
 <StackPane xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <HBox alignment="TOP_CENTER" fx:id="hBox">
       <padding>
@@ -18,37 +20,51 @@
          <Image url="/images/profile_icon.png"/>
       </ImageView>
    </HBox>
-   <VBox spacing="10" fx:id="vBox">
+   <VBox spacing="15" fx:id="vBox">
       <padding>
-         <Insets top="150" left="20" />
+         <Insets top="150" left="20" right="20" />
       </padding>
       <VBox>
          <Label styleClass="profile_information_label" text="Name"/>
-         <Label fx:id="name" styleClass="profile_big_label" text="\$name" wrapText="true"/>
+         <TextFlow>
+            <Text fx:id="name" styleClass="profile_text" text="\$name"/>
+         </TextFlow>
       </VBox>
       <VBox>
          <Label styleClass="profile_information_label" text="Phone"/>
-         <Label fx:id="phone" styleClass="profile_small_label" text="\$phone" wrapText="true"/>
+         <TextFlow>
+            <Text fx:id="phone" styleClass="profile_text" text="\$phone"/>
+         </TextFlow>
       </VBox>
       <VBox>
          <Label styleClass="profile_information_label" text="Email"/>
-         <Label fx:id="email" styleClass="profile_small_label" text="\$email" wrapText="true"/>
+         <TextFlow>
+            <Text fx:id="email" styleClass="profile_text" text="\$email"/>
+         </TextFlow>
       </VBox>
       <VBox>
          <Label styleClass="profile_information_label" text="Matriculation ID"/>
-         <Label fx:id="matriculation" styleClass="profile_small_label" text="\$matriculation" wrapText="true"/>
+         <TextFlow>
+            <Text fx:id="matriculation" styleClass="profile_text" text="\$matriculation"/>
+         </TextFlow>
       </VBox>
       <VBox>
          <Label styleClass="profile_information_label" text="Telegram"/>
-         <Label fx:id="telegram" styleClass="profile_small_label" text="\$telegram" wrapText="true"/>
+         <TextFlow>
+            <Text fx:id="telegram" styleClass="profile_text" text="\$telegram"/>
+         </TextFlow>
       </VBox>
       <VBox>
          <Label styleClass="profile_information_label" text="Course"/>
-         <Label fx:id="course" styleClass="profile_small_label" text="\$course" wrapText="true"/>
+         <TextFlow>
+            <Text fx:id="course" styleClass="profile_text" text="\$course"/>
+         </TextFlow>
       </VBox>
       <VBox>
          <Label styleClass="profile_information_label" text="Address"/>
-         <Label fx:id="address" styleClass="profile_small_label" text="\$address" wrapText="true"/>
+         <TextFlow>
+            <Text fx:id="address" styleClass="profile_text" text="\$address"/>
+         </TextFlow>
       </VBox>
       <VBox spacing="5">
          <Label styleClass="profile_information_label" text="Tags"/>

--- a/src/main/resources/view/TagList.fxml
+++ b/src/main/resources/view/TagList.fxml
@@ -5,8 +5,8 @@
 
 <StackPane xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-        <ListView fx:id="tagListView" VBox.vgrow="ALWAYS" onMouseClicked="#handleSelectTag"
-                  onKeyPressed="#handleSelectTag" onContextMenuRequested="#handleTagContextMenu"/>
+        <ListView fx:id="tagListView" VBox.vgrow="ALWAYS" onMouseClicked="#handleMouseSelect"
+                  onKeyPressed="#handleKeySelect"/>
     </VBox>
 </StackPane>
 


### PR DESCRIPTION
Bugs fixed:
1. *Bug: Long address gets cut-off*
Fixed by: Replacing `Label` to `Text` in Profile, then adding TextFlow to wrap the texts
2. *Bug: Right click -> Delete is still functional after disabling User Input*
Fixed by: Toggling right clicks and context menu before and after enabling/disabling mouseUX
3. *Bug: "Invalid command format" upon pressing any button on the keyboard when you first launch the app.*
Fixed by: This bug is caused by the `onKeyPressed` event listener sharing the same handler as `onMouseClicked` specified in fxml, resolved by splitting up the same handler.
4. *Bug: Invalid ProfileCommand being executed when clicking on blank space in PersonListPanel*
Fixed by: Specifying the `onMouseClicked` handler to execute only when there is a selected person/tag card.