### PR TITLE
Fix 1 bug

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -2,7 +2,6 @@ package seedu.address.ui;
 
 import java.io.FileNotFoundException;
 import java.util.logging.Logger;
-
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Menu;
@@ -264,21 +263,23 @@ public class MainWindow extends UiPart<Stage> {
                 generalDisplay.getTagList().toggleRightClick(false);
             }
 
-            if (commandResult.isRemoveProfile() && this.generalDisplay.getProfile().getPerson() != null
-                    && this.generalDisplay.getProfile().getPerson().isSamePerson(commandResult.getPerson())) {
-                this.generalDisplay.resetProfile();
+            // when the command is a delete command, and the current profile is displaying the person being deleted,
+            // the profile will reset and the current selection after deletion is cleared.
+            if (commandResult.isRemoveProfile() && generalDisplay.getProfile().getPerson() != null
+                    && generalDisplay.getProfile().getPerson().isSamePerson(commandResult.getPerson())) {
+                generalDisplay.resetProfile();
+                personListPanel.getPersonListView().getSelectionModel().clearSelection();
             }
 
             if (commandResult.isShowProfile()) {
-                this.generalDisplay.setProfile(commandResult.getPerson());
-                this.personListPanel.getPersonListView().scrollTo(this.generalDisplay
-                        .getProfile().getIndex().getZeroBased());
-                this.personListPanel.getPersonListView().getSelectionModel().select(this.generalDisplay
+                generalDisplay.setProfile(commandResult.getPerson());
+                personListPanel.getPersonListView().scrollTo(generalDisplay.getProfile().getIndex().getZeroBased());
+                personListPanel.getPersonListView().getSelectionModel().select(generalDisplay
                         .getProfile().getIndex().getZeroBased());
             }
 
             if (commandResult.isShowTagList()) {
-                this.generalDisplay.setTagList(logic.getModel().getTagList());
+                generalDisplay.setTagList(logic.getModel().getTagList());
             }
 
             if (commandResult.isSwitchTheme()) {
@@ -286,7 +287,7 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             if (commandResult.isShowGrabResult()) {
-                this.generalDisplay.setGrabResult(commandResult.getGrabResult());
+                generalDisplay.setGrabResult(commandResult.getGrabResult());
             }
 
             if (commandResult.isShowHelp()) {

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -118,8 +118,24 @@ public class PersonListPanel extends UiPart<Region> {
         delete.setOnAction(event -> {
             try {
                 Index personToDeleteIndex = Index.fromZeroBased(personListView.getSelectionModel().getSelectedIndex());
+                Person personToDelete = personListView.getSelectionModel().getSelectedItem();
                 DeleteCommand deleteCommand = new DeleteCommand(personToDeleteIndex);
                 CommandResult commandResult = deleteCommand.execute(logic.getModel());
+
+                // if the current profile is displaying the person being deleted, the profile will reset and the
+                // current selection after deletion is cleared.
+                Person currentPersonInProfile = UiManager.getMainWindow().getGeneralDisplay().getProfile().getPerson();
+                if (currentPersonInProfile != null && currentPersonInProfile.isSamePerson(commandResult.getPerson())) {
+                    UiManager.getMainWindow().getGeneralDisplay().resetProfile();
+                    personListView.getSelectionModel().clearSelection();
+                } else if (currentPersonInProfile != null && !currentPersonInProfile.isSamePerson(personToDelete)) {
+                    // otherwise, select the person that is currently being displayed in profile.
+                    personListView.getSelectionModel().select(currentPersonInProfile);
+                } else {
+                    // if the current profile is empty, clear the default selection.
+                    personListView.getSelectionModel().clearSelection();
+                }
+
                 UiManager.getMainWindow().getResultDisplay().setFeedbackToUser(commandResult.getFeedbackToUser());
             } catch (CommandException e) {
                 UiManager.getMainWindow().getResultDisplay().setFeedbackToUser(e.getMessage());


### PR DESCRIPTION
*Bug: After deleting `Person`, `Profile` is not updated*
Fix by: enhance the `Profile` display policy if encounters a `DeleteCommand`:
  1. Through CLI, reset `Profile` and clear the current selection if the `Person` being deleted is currently being displayed in `Profile`. If not, `Profile` will not be affected.
  2. Through mouseUX:
    - If the `Person` being deleted is currently being displayed in `Profile`, reset `Profile` and clear the current selection.
    - If `Person` being deleted is not being displayed in `Profile` and `Profile` is not empty, select the person who is being displayed. 
    - If the current `Profile` is empty, clear all the selections.