### PR TITLE
Fix clear bug, add tests 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -12,6 +12,10 @@ public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Clears all data in UNite (including profiles and tags). "
+            + "To clear UNite, enter 'clear' without any spaces or characters before and behind.\n"
+            + "To clear empty tags, enter 'clear_emptytag'.";
 
 
     @Override
@@ -19,5 +23,11 @@ public class ClearCommand extends Command {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        return (other instanceof ClearCommand);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearEmptyTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearEmptyTagCommand.java
@@ -15,7 +15,7 @@ public class ClearEmptyTagCommand extends Command {
 
     public static final String COMMAND_WORD = "clear_emptytag";
 
-    public static final String MESSAGE_SUCCESS = "Cleared %d empty tags";
+    public static final String MESSAGE_SUCCESS = "Cleared %d empty tag(s)";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -55,6 +55,11 @@ public class AddressBookParser {
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
+
+        if (commandWord.equals(ClearCommand.COMMAND_WORD)) {
+            return new ClearCommandParser().parse(userInput);
+        }
+
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
@@ -77,9 +82,6 @@ public class AddressBookParser {
 
         case DetachTagCommand.COMMAND_WORD:
             return new DetachTagCommandParser().parse(arguments);
-
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AttachTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AttachTagCommandParser.java
@@ -11,6 +11,9 @@ import seedu.address.logic.commands.AttachTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
+/**
+ * Parses input arguments and creates a new AttachTagCommand object
+ */
 public class AttachTagCommandParser implements Parser<AttachTagCommand> {
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ClearCommand object
+ */
+public class ClearCommandParser implements Parser<ClearCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ClearCommand
+     * and returns an ClearCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ClearCommand parse(String args) throws ParseException {
+        if (args.equals(ClearCommand.COMMAND_WORD)) {
+            return new ClearCommand();
+        } else {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    ClearCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -9,15 +9,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Name {
 
-    public static final String MESSAGE_CONSTRAINTS = "Names should only contain alphanumeric characters"
-            + " and spaces (maximum 50 characters including spaces),"
+    public static final String MESSAGE_CONSTRAINTS = "Names can take any values,"
             + " and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "([\\p{Alnum}][\\p{Alnum} ]*)";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -9,14 +9,15 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Name {
 
-    public static final String MESSAGE_CONSTRAINTS = "Names can take any values,"
+    public static final String MESSAGE_CONSTRAINTS = "Names should only contain alphanumeric characters"
+            + " and spaces (maximum 50 characters including spaces),"
             + " and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String VALIDATION_REGEX = "([\\p{Alnum}][\\p{Alnum} ]*)";
 
     public final String fullName;
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,8 +4,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MATRICCARD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TAG;
 
 import java.util.Arrays;
 import java.util.List;
@@ -14,20 +25,36 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddTagCommand;
+import seedu.address.logic.commands.AttachTagCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearEmptyTagCommand;
+import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteTagCommand;
+import seedu.address.logic.commands.DetachTagCommand;
+import seedu.address.logic.commands.DisableMouseUxCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EnableMouseUxCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.GrabCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListTagCommand;
+import seedu.address.logic.commands.ProfileCommand;
+import seedu.address.logic.commands.RemarkTagCommand;
+import seedu.address.logic.commands.SwitchThemeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
+import seedu.address.testutil.TagBuilder;
 
 public class AddressBookParserTest {
 
@@ -41,9 +68,41 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_addTag() throws Exception {
+        Tag tag = new TagBuilder().build();
+        AddTagCommand command = (AddTagCommand) parser.parseCommand(
+                AddTagCommand.COMMAND_WORD + " " + PREFIX_TAG + tag.tagName);
+        assertEquals(new AddTagCommand(tag), command);
+    }
+
+    @Test
+    public void parseCommand_attachTag() throws Exception {
+        Tag tag = new TagBuilder().build();
+        AttachTagCommand command = (AttachTagCommand) parser.parseCommand(
+                AttachTagCommand.COMMAND_WORD + " " + PREFIX_TAG + tag.tagName
+                        + " " + PREFIX_INDEX + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new AttachTagCommand(tag, INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_deleteTag() throws Exception {
+        DeleteTagCommand command = (DeleteTagCommand) parser.parseCommand(
+                DeleteTagCommand.COMMAND_WORD + " " + INDEX_FIRST_TAG.getOneBased());
+        assertEquals(new DeleteTagCommand(INDEX_FIRST_TAG), command);
+    }
+
+    @Test
+    public void parseCommand_detatchTag() throws Exception {
+        Tag tag = new TagBuilder().build();
+        DetachTagCommand command = (DetachTagCommand) parser.parseCommand(
+                DetachTagCommand.COMMAND_WORD + " " + PREFIX_TAG + tag.tagName
+                        + " " + PREFIX_INDEX + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new DetachTagCommand(tag, INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
     }
 
     @Test
@@ -89,6 +148,74 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_listTag() throws Exception {
+        assertTrue(parser.parseCommand(ListTagCommand.COMMAND_WORD) instanceof ListTagCommand);
+        assertTrue(parser.parseCommand(ListTagCommand.COMMAND_WORD + " 3") instanceof ListTagCommand);
+    }
+
+    @Test
+    public void parseCommand_filter() throws Exception {
+        Tag tag = new TagBuilder().build();
+        assertTrue(parser.parseCommand(FilterCommand.COMMAND_WORD + " " + tag.tagName) instanceof FilterCommand);
+    }
+
+    @Test
+    public void parseCommand_switchTheme() throws Exception {
+        assertTrue(parser.parseCommand(SwitchThemeCommand.COMMAND_WORD + " light") instanceof SwitchThemeCommand);
+        assertTrue(parser.parseCommand(SwitchThemeCommand.COMMAND_WORD + " dark") instanceof SwitchThemeCommand);
+    }
+
+    @Test
+    public void parseCommand_profile() throws Exception {
+        ProfileCommand command = (ProfileCommand) parser.parseCommand(
+                ProfileCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new ProfileCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_remarkTag() throws Exception {
+        Tag tag = new TagBuilder().build();
+        Command command = parser.parseCommand(
+                RemarkTagCommand.COMMAND_WORD + " " + PREFIX_TAG + tag.tagName + " " + PREFIX_REMARK + " ");
+        assertTrue(command instanceof RemarkTagCommand);
+    }
+
+    @Test
+    public void parseCommand_grab() throws Exception {
+        assertTrue(parser.parseCommand(GrabCommand.COMMAND_WORD + " " + PREFIX_NAME) instanceof GrabCommand);
+        assertTrue(parser.parseCommand(GrabCommand.COMMAND_WORD + " " + PREFIX_ADDRESS) instanceof GrabCommand);
+        assertTrue(parser.parseCommand(GrabCommand.COMMAND_WORD + " " + PREFIX_EMAIL) instanceof GrabCommand);
+        assertTrue(parser.parseCommand(GrabCommand.COMMAND_WORD + " " + PREFIX_PHONE) instanceof GrabCommand);
+        assertTrue(parser.parseCommand(GrabCommand.COMMAND_WORD + " " + PREFIX_COURSE) instanceof GrabCommand);
+        assertTrue(parser.parseCommand(GrabCommand.COMMAND_WORD + " " + PREFIX_MATRICCARD) instanceof GrabCommand);
+        assertTrue(parser.parseCommand(GrabCommand.COMMAND_WORD + " " + PREFIX_TELEGRAM) instanceof GrabCommand);
+
+        //parse with a tag
+        Tag tag = new TagBuilder().build();
+        Command command = parser.parseCommand(GrabCommand.COMMAND_WORD
+                + " " + PREFIX_TELEGRAM + " " + PREFIX_TAG + tag.tagName);
+        assertTrue(command instanceof GrabCommand);
+    }
+
+    @Test
+    public void parseCommand_clearEmptyTag() throws Exception {
+        assertTrue(parser.parseCommand(ClearEmptyTagCommand.COMMAND_WORD) instanceof ClearEmptyTagCommand);
+        assertTrue(parser.parseCommand(ClearEmptyTagCommand.COMMAND_WORD + " 3") instanceof ClearEmptyTagCommand);
+    }
+
+    @Test
+    public void parseCommand_enableMouseUX() throws Exception {
+        assertTrue(parser.parseCommand(EnableMouseUxCommand.COMMAND_WORD) instanceof EnableMouseUxCommand);
+        assertTrue(parser.parseCommand(EnableMouseUxCommand.COMMAND_WORD + " 3") instanceof EnableMouseUxCommand);
+    }
+
+    @Test
+    public void parseCommand_disableMouseUX() throws Exception {
+        assertTrue(parser.parseCommand(DisableMouseUxCommand.COMMAND_WORD) instanceof DisableMouseUxCommand);
+        assertTrue(parser.parseCommand(DisableMouseUxCommand.COMMAND_WORD + " 3") instanceof DisableMouseUxCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ClearCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClearCommandParserTest.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ClearCommand;
+
+public class ClearCommandParserTest {
+
+    private ClearCommandParser parser = new ClearCommandParser();
+
+    @Test
+    public void parse_emptyArg_returnsClearCommand() {
+        ClearCommand expectedCommand = new ClearCommand();
+        assertParseSuccess(parser, "clear", expectedCommand);
+    }
+
+    @Test
+    public void parse_notEmptyArg_throwsParseException() {
+        assertParseFailure(parser, "clear ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClearCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "clear  abc",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClearCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "  clear",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClearCommand.MESSAGE_USAGE));
+    }
+
+}


### PR DESCRIPTION
* Fixed the problem where users might accidentally enter `clear emptytag` and clear the whole UNite.
* Now, in order to clear Unite, users must enter `clear` without any extra space or character in front or behind the keyword
* Added test for AddressBookParser
* Added ClearCommandParser, including test